### PR TITLE
センシティブな投稿の画像をぼかす

### DIFF
--- a/static/css/note.css
+++ b/static/css/note.css
@@ -80,3 +80,19 @@
   border: 1px dotted black;
   border-radius: 5px;
 }
+
+.sensitive-image-label {
+  /*center the text*/
+  z-index: 1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.1em;
+  color: white;
+  -webkit-text-stroke: 0.6px #000;
+}
+
+.sensitive-image-blur {
+  filter: blur(20px);
+}

--- a/templates/note.html
+++ b/templates/note.html
@@ -86,15 +86,18 @@
       <div class="content">{{.Note.Basic.Content.RawHTML}}</div>
       {{if .Note.Basic.Uploads}}
       <div role="group" aria-label="アップロード画像リスト">
-        {{range .Note.Basic.Uploads}} {{if $.Note.Basic.Sensitive}}
-        <a href="/upload/{{.}}" target="_blank">画像を見る (sensitive)</a>
-        {{else}}
+        {{range .Note.Basic.Uploads}}
         <a href="/upload/{{.}}" target="_blank">
           <figure>
+            {{if $.Note.Basic.Sensitive}}
+            <span class="sensitive-image-label">センシティブ</span>
+            <img src="/upload/{{.}}" alt="アップロード画像" class="upload sensitive-image-blur" />
+            {{else}}
             <img src="/upload/{{.}}" alt="アップロード画像" class="upload" />
+            {{end}}
           </figure>
         </a>
-        {{end}} {{end}}
+        {{end}}
       </div>
       {{end}}
     </div>


### PR DESCRIPTION
センシティブに設定された投稿の画像をCSSでぼかすようにした
画像は通常の投稿と同様にクリックすることで表示できる