### PR TITLE
プロフィール画面でブロックとブロック解除が逆になっている問題を修正

### DIFF
--- a/templates/topProfile.html
+++ b/templates/topProfile.html
@@ -151,14 +151,14 @@
                     hx-ext="json-enc"
                   >
                     {{if .User.Details.IsBlocking}}
-                    <input type="hidden" name="type" value="block" />
-                    <button type="submit" class="dropdown-item">
-                      ブロック
-                    </button>
-                    {{else}}
                     <input type="hidden" name="type" value="unblock" />
                     <button type="submit" class="dropdown-item">
                       ブロック解除
+                    </button>
+                    {{else}}
+                    <input type="hidden" name="type" value="block" />
+                    <button type="submit" class="dropdown-item">
+                      ブロック
                     </button>
                     {{end}}
                   </form>


### PR DESCRIPTION
ユーザーのプロフィールページ上でブロックしていないユーザーには詳細メニューにブロックの項目が、ブロックしているユーザーに対してはブロック解除の項目が表示されるべきだが、ブロックしていないユーザーにブロック解除の項目のみが表示され、ユーザーをブロックすることができない不具合が存在していた。
このプルリクエストではこの不具合の修正を行った。